### PR TITLE
tests: fix switched privkey, pubkey error output

### DIFF
--- a/tests/sign-verify-data-newapi.c
+++ b/tests/sign-verify-data-newapi.c
@@ -91,11 +91,11 @@ void doit(void)
 
 		ret = gnutls_pubkey_init(&pubkey);
 		if (ret < 0)
-			testfail("gnutls_privkey_init\n");
+			testfail("gnutls_pubkey_init\n");
 
 		ret = gnutls_privkey_init(&privkey);
 		if (ret < 0)
-			testfail("gnutls_pubkey_init\n");
+			testfail("gnutls_privkey_init\n");
 
 		ret = gnutls_privkey_import_x509_raw(privkey, &tests[i].key, GNUTLS_X509_FMT_PEM, NULL, 0);
 		if (ret < 0)


### PR DESCRIPTION
testfail outputs for gnutls_pubkey_init and gnutls_privkey_init are switched.
This PR fixes this.