### PR TITLE
configure.ac: check if libatomic is needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,8 @@ dnl Need netinet/tcp.h for TCP_FASTOPEN
 AC_CHECK_HEADERS([netinet/tcp.h])
 AC_CHECK_HEADERS([stdatomic.h])
 
+AC_SEARCH_LIBS([__atomic_load_4], [atomic], [AC_SUBST([LIBATOMIC_LIBS], [-latomic])])
+
 dnl We use its presence to detect C11 threads
 AC_CHECK_HEADERS([threads.h])
 

--- a/lib/gnutls.pc.in
+++ b/lib/gnutls.pc.in
@@ -19,6 +19,6 @@ Description: Transport Security Layer implementation for the GNU system
 URL: http://www.gnutls.org/
 Version: @VERSION@
 Libs: -L${libdir} -lgnutls
-Libs.private: @LIBINTL@ @LIBSOCKET@ @LIBNSL@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBIDN2_LIBS@
+Libs.private: @LIBINTL@ @LIBSOCKET@ @LIBNSL@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBIDN2_LIBS@ @LIBATOMIC_LIBS@
 @GNUTLS_REQUIRES_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
gnutls source code uses the C++11 <atomic> functionality since
https://github.com/gnutls/gnutls/commit/7978a733460f92b31033affd0e487c86d66c643d,
which internally is implemented using the __atomic_*() gcc built-ins

On certain architectures, the __atomic_*() built-ins are implemented in
the libatomic library that comes with the rest of the gcc runtime. Due
to this, code using <atomic> might need to link against libatomic,
otherwise one hits build issues such as:

../lib/.libs/libgnutls.so: undefined reference to `__atomic_fetch_sub_4'

on an architecture like SPARC.

To solve this, a configure.ac check is added to know if we need to
link against libatomic or not. The library is also added to gnutls.pc.

Fixes:
 - http://autobuild.buildroot.org/results/6c749bd592ceffeacadd2ab570d127936cce64b2
 - http://autobuild.buildroot.org/results/30aa83d3cf3482af8a59250c196c85f4a278d343

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>