### PR TITLE
configure: check that -no_weak_links works with FD_SET

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ case "$host" in
     dnl intended minimum runtime version.
     LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
     AC_MSG_CHECKING([whether the linker supports -Wl,-no_weak_imports])
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <sys/select.h>], [fd_set rfds; FD_ZERO(&rfds); FD_SET(0, &rfds);])],
       [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no); LDFLAGS="$save_LDFLAGS"])
   ;;
   *solaris*)


### PR DESCRIPTION
Several Xcode/SDK versions provide FD_SET implementation that does not
work with -no_weak_links. Check that this option does not break FD_SET
usage.

Fixes #966

Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>