### PR TITLE
add missing Build prerequisites

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
       - name: install dependencies
         run: |
           brew update
-          for pkg in openssl autoconf automake libtool nettle p11-kit libtasn1 gettext bison; do
+          for pkg in openssl autoconf automake libtool nettle p11-kit libtasn1 gettext bison gtk-doc; do
             brew install $pkg || true
           done
           for pkg in nettle wget p11-kit libtasn1; do

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -50,7 +50,8 @@ git        1.4.4
 perl       5.5
 gperf      -
 autopoint  -
-gtkdocize  -
+gtk-doc-tools  -
+gnulib -
 "
 
 # update git submodules

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -50,7 +50,7 @@ git        1.4.4
 perl       5.5
 gperf      -
 autopoint  -
-gtk-doc-tools  -
+gtk-doc-tools -
 gnulib -
 "
 


### PR DESCRIPTION
curl zuul build failed because of this: https://curl.zuul.vexxhost.dev/build/9225fd94df0e4dcca60e9bb068083e98/console