### PR TITLE
lib: fix two segfault issues caused by freeing uninitialized buf

### DIFF
--- a/lib/tls13/early_data.c
+++ b/lib/tls13/early_data.c
@@ -88,18 +88,14 @@ int _gnutls13_recv_end_of_early_data(gnutls_session_t session)
 		if (ret < 0)
 			return gnutls_assert_val(ret);
 
+		_gnutls_buffer_clear(&buf);
+
 		if (buf.length != 0) {
-			gnutls_assert();
 			ret = GNUTLS_E_RECEIVED_ILLEGAL_PARAMETER;
-			goto cleanup;
+			return gnutls_assert_val(ret);
 		}
 	}
 
 	session->internals.hsk_flags &= ~HSK_EARLY_DATA_IN_FLIGHT;
-
-	ret = 0;
-cleanup:
-
-	_gnutls_buffer_clear(&buf);
-	return ret;
+	return 0;
 }

--- a/lib/tls13/finished.c
+++ b/lib/tls13/finished.c
@@ -82,10 +82,8 @@ int _gnutls13_recv_finished(gnutls_session_t session)
 	ret = _gnutls13_compute_finished(
 		session->security_parameters.prf, base_key,
 		&session->internals.handshake_hash_buffer, verifier);
-	if (ret < 0) {
-		gnutls_assert();
-		goto cleanup;
-	}
+	if (ret < 0)
+		return gnutls_assert_val(ret);
 
 	ret = _gnutls_recv_handshake(session, GNUTLS_HANDSHAKE_FINISHED, 0,
 				     &buf);


### PR DESCRIPTION
The first one was found in my app running on aarch64 machine where I think stack variables are not initialized by default, and the 2nd one was noticed by reviewing code only.